### PR TITLE
Require scribble/eval

### DIFF
--- a/sexp-diff/sexp-diff.scrbl
+++ b/sexp-diff/sexp-diff.scrbl
@@ -1,6 +1,7 @@
 #lang scribble/doc
 
 @(require
+  scribble/eval
   scribble/manual
   (for-label
    racket/base


### PR DESCRIPTION
This is for the pre-racket-6.4 branch, used as a package version
exception branch.

I locally installed Racket 6.3 and did a `raco pkg install` to confirm
this builds without an error.